### PR TITLE
Feature/effort

### DIFF
--- a/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
+++ b/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
@@ -52,7 +52,7 @@ enum class ControlMode
   Position,
   Velocity,
   Torque,
-  Currrent,
+  Current,
   ExtendedPosition,
   MultiTurn,
   CurrentBasedPosition,

--- a/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
+++ b/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
@@ -95,6 +95,7 @@ private:
   std::map<const char * const, const ControlItem *> control_items_;
   std::vector<Joint> joints_;
   std::vector<uint8_t> joint_ids_;
+  std::vector<double> effort_to_current_coefs_;
   bool torque_enabled_{false};
   ControlMode control_mode_{ControlMode::Position};
   bool use_dummy_{false};

--- a/dynamixel_hardware/src/dynamixel_hardware.cpp
+++ b/dynamixel_hardware/src/dynamixel_hardware.cpp
@@ -275,6 +275,8 @@ return_type DynamixelHardware::write()
   if (use_dummy_) {
     for (auto & joint : joints_) {
       joint.state.position = joint.command.position;
+      joint.state.velocity = joint.command.velocity;
+      joint.state.effort = joint.command.effort;
     }
 
     return return_type::OK;

--- a/dynamixel_hardware/src/dynamixel_hardware.cpp
+++ b/dynamixel_hardware/src/dynamixel_hardware.cpp
@@ -194,6 +194,8 @@ std::vector<hardware_interface::CommandInterface> DynamixelHardware::export_comm
       info_.joints[i].name, hardware_interface::HW_IF_POSITION, &joints_[i].command.position));
     command_interfaces.emplace_back(hardware_interface::CommandInterface(
       info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &joints_[i].command.velocity));
+    command_interfaces.emplace_back(hardware_interface::CommandInterface(
+      info_.joints[i].name, hardware_interface::HW_IF_EFFORT, &joints_[i].command.effort));
   }
 
   return command_interfaces;

--- a/dynamixel_hardware/src/dynamixel_hardware.cpp
+++ b/dynamixel_hardware/src/dynamixel_hardware.cpp
@@ -319,7 +319,7 @@ return_type DynamixelHardware::write(
   if (std::any_of(
         joints_.cbegin(), joints_.cend(), [](auto j) { return j.command.effort != 0.0; })) {
     // Effort control
-    if (set_control_mode(ControlMode::Currrent) == return_type::ERROR) {
+    if (set_control_mode(ControlMode::Current) == return_type::ERROR) {
       return return_type::ERROR;
     }
     for (uint i = 0; i < ids.size(); i++) {
@@ -416,7 +416,7 @@ return_type DynamixelHardware::set_control_mode(const ControlMode & mode, const 
   const char * log = nullptr;
   mode_changed_ = false;
 
-  if (mode == ControlMode::Currrent && (force_set || control_mode_ != ControlMode::Currrent)) {
+  if (mode == ControlMode::Current && (force_set || control_mode_ != ControlMode::Current)) {
     bool torque_enabled = torque_enabled_;
     if (torque_enabled) {
       enable_torque(false);
@@ -429,7 +429,7 @@ return_type DynamixelHardware::set_control_mode(const ControlMode & mode, const 
       }
     }
     RCLCPP_INFO(rclcpp::get_logger(kDynamixelHardware), "Current control");
-    control_mode_ = ControlMode::Currrent;
+    control_mode_ = ControlMode::Current;
 
     if (torque_enabled) {
       enable_torque(true);
@@ -481,7 +481,7 @@ return_type DynamixelHardware::set_control_mode(const ControlMode & mode, const 
       enable_torque(true);
     }
   } else if (
-    control_mode_ != ControlMode::Currrent && control_mode_ != ControlMode::Velocity &&
+    control_mode_ != ControlMode::Current && control_mode_ != ControlMode::Velocity &&
     control_mode_ != ControlMode::Position) {
     RCLCPP_FATAL(
       rclcpp::get_logger(kDynamixelHardware),

--- a/open_manipulator_x_description/urdf/open_manipulator_x.ros2_control.xacro
+++ b/open_manipulator_x_description/urdf/open_manipulator_x.ros2_control.xacro
@@ -14,6 +14,7 @@
         <param name="id">11</param>
         <command_interface name="position"/>
         <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position"/>
         <state_interface name="velocity"/>
         <state_interface name="effort"/>
@@ -22,6 +23,7 @@
         <param name="id">12</param>
         <command_interface name="position"/>
         <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position"/>
         <state_interface name="velocity"/>
         <state_interface name="effort"/>
@@ -30,6 +32,7 @@
         <param name="id">13</param>
         <command_interface name="position"/>
         <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position"/>
         <state_interface name="velocity"/>
         <state_interface name="effort"/>
@@ -38,6 +41,7 @@
         <param name="id">14</param>
         <command_interface name="position"/>
         <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position"/>
         <state_interface name="velocity"/>
         <state_interface name="effort"/>
@@ -46,6 +50,7 @@
         <param name="id">15</param>
         <command_interface name="position"/>
         <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position"/>
         <state_interface name="velocity"/>
         <state_interface name="effort"/>

--- a/open_manipulator_x_description/urdf/open_manipulator_x.ros2_control_gazebo.xacro
+++ b/open_manipulator_x_description/urdf/open_manipulator_x.ros2_control_gazebo.xacro
@@ -10,6 +10,7 @@
       <joint name="joint1">
         <command_interface name="position"/>
         <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position"/>
         <state_interface name="velocity"/>
         <state_interface name="effort"/>
@@ -17,6 +18,7 @@
       <joint name="joint2">
         <command_interface name="position"/>
         <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position"/>
         <state_interface name="velocity"/>
         <state_interface name="effort"/>
@@ -24,6 +26,7 @@
       <joint name="joint3">
         <command_interface name="position"/>
         <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position"/>
         <state_interface name="velocity"/>
         <state_interface name="effort"/>
@@ -31,6 +34,7 @@
       <joint name="joint4">
         <command_interface name="position"/>
         <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position"/>
         <state_interface name="velocity"/>
         <state_interface name="effort"/>
@@ -38,6 +42,7 @@
       <joint name="gripper">
         <command_interface name="position"/>
         <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position"/>
         <state_interface name="velocity"/>
         <state_interface name="effort"/>

--- a/pantilt_bot_description/urdf/pantilt_bot.ros2_control.xacro
+++ b/pantilt_bot_description/urdf/pantilt_bot.ros2_control.xacro
@@ -14,6 +14,7 @@
         <param name="id">11</param>
         <command_interface name="position"/>
         <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position"/>
         <state_interface name="velocity"/>
         <state_interface name="effort"/>
@@ -22,6 +23,7 @@
         <param name="id">12</param>
         <command_interface name="position"/>
         <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position"/>
         <state_interface name="velocity"/>
         <state_interface name="effort"/>

--- a/pantilt_bot_description/urdf/pantilt_bot.ros2_control_gazebo.xacro
+++ b/pantilt_bot_description/urdf/pantilt_bot.ros2_control_gazebo.xacro
@@ -10,6 +10,7 @@
       <joint name="joint1">
         <command_interface name="position"/>
         <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position"/>
         <state_interface name="velocity"/>
         <state_interface name="effort"/>
@@ -17,6 +18,7 @@
       <joint name="joint2">
         <command_interface name="position"/>
         <command_interface name="velocity"/>
+        <command_interface name="effort"/>
         <state_interface name="position"/>
         <state_interface name="velocity"/>
         <state_interface name="effort"/>


### PR DESCRIPTION
This pull request introduces effort control functionality to the `DynamixelHardware` class and updates the URDF files to include effort command interfaces. The key changes include the addition of effort control coefficients, the implementation of effort control mode, and updates to the hardware configuration and read/write methods.

Effort control implementation:

* Added `effort_to_current_coefs_` vector to the `DynamixelHardware` class to store coefficients for converting effort to current (`dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp`).
* Implemented effort control mode in the `write` method, including the conversion of effort commands to current values (`dynamixel_hardware/src/dynamixel_hardware.cpp`).
* Updated the `set_control_mode` method to handle the new `ControlMode::Currrent` for effort control (`dynamixel_hardware/src/dynamixel_hardware.cpp`). [[1]](diffhunk://#diff-6273b1d2089bdf6913f5848f9a607c552501d1a65e573cc3adbf68bb5d3d7d9aL354-R399) [[2]](diffhunk://#diff-6273b1d2089bdf6913f5848f9a607c552501d1a65e573cc3adbf68bb5d3d7d9aL391-R441)

Hardware configuration updates:

* Resized the `effort_to_current_coefs_` vector during hardware configuration (`dynamixel_hardware/src/dynamixel_hardware.cpp`).
* Added effort command interfaces to the `export_command_interfaces` method (`dynamixel_hardware/src/dynamixel_hardware.cpp`).

URDF file updates:

* Added `effort` command and state interfaces to the joints in `open_manipulator_x_description` and `pantilt_bot_description` URDF files (`open_manipulator_x_description/urdf/open_manipulator_x.ros2_control.xacro`, `open_manipulator_x_description/urdf/open_manipulator_x.ros2_control_gazebo.xacro`, `pantilt_bot_description/urdf/pantilt_bot.ros2_control.xacro`, `pantilt_bot_description/urdf/pantilt_bot.ros2_control_gazebo.xacro`). [[1]](diffhunk://#diff-e3673a4aa639d385828fae437100939f73f60abb7385961be99a78fbcb7c1e17R17) [[2]](diffhunk://#diff-e3673a4aa639d385828fae437100939f73f60abb7385961be99a78fbcb7c1e17R26) [[3]](diffhunk://#diff-e3673a4aa639d385828fae437100939f73f60abb7385961be99a78fbcb7c1e17R35) [[4]](diffhunk://#diff-e3673a4aa639d385828fae437100939f73f60abb7385961be99a78fbcb7c1e17R44) [[5]](diffhunk://#diff-e3673a4aa639d385828fae437100939f73f60abb7385961be99a78fbcb7c1e17R53) [[6]](diffhunk://#diff-af76360b2af67fad5fc508c614a119d1330a7a4f1730c13d965f2a03529e8b58R13-R45) [[7]](diffhunk://#diff-d0c94edd67627abc00f5bf2622dc558d1db08a7f658ecf1e967bc0419f681789R17) [[8]](diffhunk://#diff-d0c94edd67627abc00f5bf2622dc558d1db08a7f658ecf1e967bc0419f681789R26) [[9]](diffhunk://#diff-98d70356342f4a74779e0e715407165f4ec512692c13c980f4cd6e6cf0f01bdcR13-R21)