### PR TITLE
Feature/humble/current based control

### DIFF
--- a/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
+++ b/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
@@ -100,6 +100,7 @@ private:
 
   CallbackReturn set_joint_positions();
   CallbackReturn set_joint_velocities();
+  CallbackReturn set_joint_currents();
   CallbackReturn set_joint_params();
 
   DynamixelWorkbench dynamixel_workbench_;

--- a/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
+++ b/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
@@ -109,7 +109,6 @@ private:
   bool torque_enabled_{false};
   ControlMode control_mode_{ControlMode::NoControl};
   ControlMode prev_control_mode_{ControlMode::NoControl};
-  bool mode_changed_{false};
   bool use_dummy_{false};
 };
 }  // namespace dynamixel_hardware

--- a/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
+++ b/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
@@ -44,7 +44,6 @@ struct Joint
 {
   JointValue state{};
   JointValue command{};
-  JointValue prev_command{};
 };
 
 enum class ControlMode {

--- a/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
+++ b/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
@@ -50,7 +50,7 @@ enum class ControlMode {
   Position,
   Velocity,
   Torque,
-  Currrent,
+  Current,
   ExtendedPosition,
   MultiTurn,
   CurrentBasedPosition,

--- a/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
+++ b/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
@@ -94,7 +94,7 @@ public:
 private:
   return_type enable_torque(const bool enabled);
 
-  return_type set_control_mode(const ControlMode & mode, const bool force_set = false);
+  return_type set_control_mode(const ControlMode & mode);
 
   return_type reset_command();
 
@@ -108,6 +108,7 @@ private:
   std::vector<uint8_t> joint_ids_;
   bool torque_enabled_{false};
   ControlMode control_mode_{ControlMode::NoControl};
+  ControlMode prev_control_mode_{ControlMode::NoControl};
   bool mode_changed_{false};
   bool use_dummy_{false};
 };

--- a/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
+++ b/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
@@ -106,6 +106,8 @@ private:
   std::map<const char * const, const ControlItem *> control_items_;
   std::vector<Joint> joints_;
   std::vector<uint8_t> joint_ids_;
+  std::vector<uint8_t> joint_ids_ttl_;
+  std::vector<uint8_t> joint_ids_rs_;
   bool torque_enabled_{false};
   ControlMode control_mode_{ControlMode::NoControl};
   ControlMode prev_control_mode_{ControlMode::NoControl};

--- a/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
+++ b/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
@@ -74,13 +74,12 @@ public:
   std::vector<hardware_interface::CommandInterface> export_command_interfaces() override;
 
   DYNAMIXEL_HARDWARE_PUBLIC
-  CallbackReturn on_activate(const rclcpp_lifecycle::State & previous_state) override;
-
-  DYNAMIXEL_HARDWARE_PUBLIC
   return_type prepare_command_mode_switch(
     const std::vector<std::string> & start_interfaces,
     const std::vector<std::string> & stop_interfaces) override;
-
+  
+  DYNAMIXEL_HARDWARE_PUBLIC
+  CallbackReturn on_activate(const rclcpp_lifecycle::State & previous_state) override;
 
   DYNAMIXEL_HARDWARE_PUBLIC
   CallbackReturn on_deactivate(const rclcpp_lifecycle::State & previous_state) override;

--- a/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
+++ b/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
@@ -55,6 +55,7 @@ enum class ControlMode {
   MultiTurn,
   CurrentBasedPosition,
   PWM,
+  NoControl,
 };
 
 class DynamixelHardware
@@ -74,6 +75,12 @@ public:
 
   DYNAMIXEL_HARDWARE_PUBLIC
   CallbackReturn on_activate(const rclcpp_lifecycle::State & previous_state) override;
+
+  DYNAMIXEL_HARDWARE_PUBLIC
+  return_type prepare_command_mode_switch(
+    const std::vector<std::string> & start_interfaces,
+    const std::vector<std::string> & stop_interfaces) override;
+
 
   DYNAMIXEL_HARDWARE_PUBLIC
   CallbackReturn on_deactivate(const rclcpp_lifecycle::State & previous_state) override;
@@ -100,7 +107,7 @@ private:
   std::vector<Joint> joints_;
   std::vector<uint8_t> joint_ids_;
   bool torque_enabled_{false};
-  ControlMode control_mode_{ControlMode::Position};
+  ControlMode control_mode_{ControlMode::NoControl};
   bool mode_changed_{false};
   bool use_dummy_{false};
 };

--- a/dynamixel_hardware/src/dynamixel_hardware.cpp
+++ b/dynamixel_hardware/src/dynamixel_hardware.cpp
@@ -80,7 +80,7 @@ CallbackReturn DynamixelHardware::on_init(const hardware_interface::HardwareInfo
 
   if (
     info_.hardware_parameters.find("use_dummy") != info_.hardware_parameters.end() &&
-    info_.hardware_parameters.at("use_dummy") == "true") {
+    (info_.hardware_parameters.at("use_dummy") == "true" || info_.hardware_parameters.at("use_dummy") == "True")) {
     use_dummy_ = true;
     RCLCPP_INFO(rclcpp::get_logger(kDynamixelHardware), "dummy mode");
     return CallbackReturn::SUCCESS;

--- a/dynamixel_hardware/src/dynamixel_hardware.cpp
+++ b/dynamixel_hardware/src/dynamixel_hardware.cpp
@@ -67,9 +67,6 @@ CallbackReturn DynamixelHardware::on_init(const hardware_interface::HardwareInfo
     joints_[i].command.position = std::numeric_limits<double>::quiet_NaN();
     joints_[i].command.velocity = std::numeric_limits<double>::quiet_NaN();
     joints_[i].command.effort = std::numeric_limits<double>::quiet_NaN();
-    joints_[i].prev_command.position = joints_[i].command.position;
-    joints_[i].prev_command.velocity = joints_[i].command.velocity;
-    joints_[i].prev_command.effort = joints_[i].command.effort;
     RCLCPP_INFO(rclcpp::get_logger(kDynamixelHardware), "joint_id %d: %d", i, joint_ids_[i]);
   }
 
@@ -284,41 +281,9 @@ return_type DynamixelHardware::write(const rclcpp::Time & /* time */, const rclc
 {
   if (use_dummy_) {
     for (auto & joint : joints_) {
-      joint.prev_command.position = joint.command.position;
       joint.state.position = joint.command.position;
     }
     return return_type::OK;
-  }
-
-  // Velocity control
-  if (std::any_of(
-        joints_.cbegin(), joints_.cend(), [](auto j) { return j.command.velocity != j.prev_command.velocity; })) {
-    set_control_mode(ControlMode::Velocity);
-    if(mode_changed_)
-    {
-      set_joint_params();
-    }
-    set_joint_velocities();
-    return return_type::OK;
-  }
-  
-  // Position control
-  if (std::any_of(
-        joints_.cbegin(), joints_.cend(), [](auto j) { return j.command.position != j.prev_command.position; })) {
-    set_control_mode(ControlMode::Position);
-    if(mode_changed_)
-    {
-      set_joint_params();
-    }
-    set_joint_positions();
-    return return_type::OK;
-  }
-
-  // Effort control
-  if (std::any_of(
-               joints_.cbegin(), joints_.cend(), [](auto j) { return j.command.effort != 0.0; })) {
-    RCLCPP_ERROR(rclcpp::get_logger(kDynamixelHardware), "Effort control is not implemented");
-    return return_type::ERROR;
   }
 
   // if all command values are unchanged, then remain in existing control mode and set corresponding command values
@@ -436,9 +401,6 @@ return_type DynamixelHardware::reset_command()
     joints_[i].command.position = joints_[i].state.position;
     joints_[i].command.velocity = 0.0;
     joints_[i].command.effort = 0.0;
-    joints_[i].prev_command.position = joints_[i].command.position;
-    joints_[i].prev_command.velocity = joints_[i].command.velocity;
-    joints_[i].prev_command.effort = joints_[i].command.effort;
   }
 
   return return_type::OK;
@@ -452,7 +414,6 @@ CallbackReturn DynamixelHardware::set_joint_positions()
 
   std::copy(joint_ids_.begin(), joint_ids_.end(), ids.begin());
   for (uint i = 0; i < ids.size(); i++) {
-    joints_[i].prev_command.position = joints_[i].command.position;
     commands[i] = dynamixel_workbench_.convertRadian2Value(
       ids[i], static_cast<float>(joints_[i].command.position));
   }
@@ -471,7 +432,6 @@ CallbackReturn DynamixelHardware::set_joint_velocities()
 
   std::copy(joint_ids_.begin(), joint_ids_.end(), ids.begin());
   for (uint i = 0; i < ids.size(); i++) {
-    joints_[i].prev_command.velocity = joints_[i].command.velocity;
     commands[i] = dynamixel_workbench_.convertVelocity2Value(
       ids[i], static_cast<float>(joints_[i].command.velocity));
   }

--- a/dynamixel_hardware/src/dynamixel_hardware.cpp
+++ b/dynamixel_hardware/src/dynamixel_hardware.cpp
@@ -424,7 +424,6 @@ return_type DynamixelHardware::enable_torque(const bool enabled)
 return_type DynamixelHardware::set_control_mode(const ControlMode & mode)
 {
   const char * log = nullptr;
-  mode_changed_ = false;
 
   if (mode == ControlMode::NoControl) {
     if (torque_enabled_) {
@@ -438,7 +437,6 @@ return_type DynamixelHardware::set_control_mode(const ControlMode & mode)
       }
     }
     RCLCPP_INFO(rclcpp::get_logger(kDynamixelHardware), "Position control,but no torque mode");
-    mode_changed_ = true;
 
     return return_type::OK;
   }
@@ -455,7 +453,6 @@ return_type DynamixelHardware::set_control_mode(const ControlMode & mode)
       }
     }
     RCLCPP_INFO(rclcpp::get_logger(kDynamixelHardware), "Velocity control");
-    mode_changed_ = true;
 
     enable_torque(true);
     return return_type::OK;
@@ -473,7 +470,6 @@ return_type DynamixelHardware::set_control_mode(const ControlMode & mode)
       }
     }
     RCLCPP_INFO(rclcpp::get_logger(kDynamixelHardware), "Position control");
-    mode_changed_ = true;
 
     enable_torque(true);
     return return_type::OK;

--- a/dynamixel_hardware/src/dynamixel_hardware.cpp
+++ b/dynamixel_hardware/src/dynamixel_hardware.cpp
@@ -200,6 +200,8 @@ std::vector<hardware_interface::CommandInterface> DynamixelHardware::export_comm
       info_.joints[i].name, hardware_interface::HW_IF_POSITION, &joints_[i].command.position));
     command_interfaces.emplace_back(hardware_interface::CommandInterface(
       info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &joints_[i].command.velocity));
+    command_interfaces.emplace_back(hardware_interface::CommandInterface(
+      info_.joints[i].name, hardware_interface::HW_IF_EFFORT, &joints_[i].command.effort));
   }
 
   return command_interfaces;

--- a/dynamixel_hardware/src/dynamixel_hardware.cpp
+++ b/dynamixel_hardware/src/dynamixel_hardware.cpp
@@ -196,12 +196,20 @@ std::vector<hardware_interface::StateInterface> DynamixelHardware::export_state_
   RCLCPP_DEBUG(rclcpp::get_logger(kDynamixelHardware), "export_state_interfaces");
   std::vector<hardware_interface::StateInterface> state_interfaces;
   for (uint i = 0; i < info_.joints.size(); i++) {
-    state_interfaces.emplace_back(hardware_interface::StateInterface(
-      info_.joints[i].name, hardware_interface::HW_IF_POSITION, &joints_[i].state.position));
-    state_interfaces.emplace_back(hardware_interface::StateInterface(
-      info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &joints_[i].state.velocity));
-    state_interfaces.emplace_back(hardware_interface::StateInterface(
-      info_.joints[i].name, hardware_interface::HW_IF_EFFORT, &joints_[i].state.effort));
+    for(auto joint_interface:info_.joints[i].state_interfaces){
+      if(joint_interface.name == hardware_interface::HW_IF_POSITION){
+        state_interfaces.emplace_back(hardware_interface::StateInterface(
+          info_.joints[i].name, hardware_interface::HW_IF_POSITION, &joints_[i].state.position));
+      }
+      if(joint_interface.name == hardware_interface::HW_IF_VELOCITY){
+        state_interfaces.emplace_back(hardware_interface::StateInterface(
+          info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &joints_[i].state.velocity));
+      }
+      if(joint_interface.name == hardware_interface::HW_IF_EFFORT){
+        state_interfaces.emplace_back(hardware_interface::StateInterface(
+          info_.joints[i].name, hardware_interface::HW_IF_EFFORT, &joints_[i].state.effort));
+      }
+    }
   }
 
   return state_interfaces;
@@ -212,12 +220,20 @@ std::vector<hardware_interface::CommandInterface> DynamixelHardware::export_comm
   RCLCPP_DEBUG(rclcpp::get_logger(kDynamixelHardware), "export_command_interfaces");
   std::vector<hardware_interface::CommandInterface> command_interfaces;
   for (uint i = 0; i < info_.joints.size(); i++) {
-    command_interfaces.emplace_back(hardware_interface::CommandInterface(
-      info_.joints[i].name, hardware_interface::HW_IF_POSITION, &joints_[i].command.position));
-    command_interfaces.emplace_back(hardware_interface::CommandInterface(
-      info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &joints_[i].command.velocity));
-    command_interfaces.emplace_back(hardware_interface::CommandInterface(
-      info_.joints[i].name, hardware_interface::HW_IF_EFFORT, &joints_[i].command.effort));
+    for(auto joint_interface:info_.joints[i].command_interfaces){
+      if(joint_interface.name == hardware_interface::HW_IF_POSITION){
+        command_interfaces.emplace_back(hardware_interface::CommandInterface(
+          info_.joints[i].name, hardware_interface::HW_IF_POSITION, &joints_[i].command.position));
+      }
+      if(joint_interface.name == hardware_interface::HW_IF_VELOCITY){
+        command_interfaces.emplace_back(hardware_interface::CommandInterface(
+          info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &joints_[i].command.velocity));
+      }
+      if(joint_interface.name == hardware_interface::HW_IF_EFFORT){
+        command_interfaces.emplace_back(hardware_interface::CommandInterface(
+          info_.joints[i].name, hardware_interface::HW_IF_EFFORT, &joints_[i].command.effort));
+      }
+    }
   }
 
   return command_interfaces;


### PR DESCRIPTION
This pull request includes significant updates to the `DynamixelHardware` class and associated files to enhance control mode management, add new control modes, and improve the handling of joint states and commands. The most important changes include the addition of a new control mode, improvements in command and state interface handling, and the introduction of protocol-specific joint ID management.

### Control Mode Enhancements:
* Added a new `NoControl` mode to the `ControlMode` enum and updated the default control mode to `NoControl` in the `DynamixelHardware` class. [[1]](diffhunk://#diff-24099be97b136de923f156b9a60267724081cdfaee4ef935be248dd9ea5f6227L47-R58) [[2]](diffhunk://#diff-24099be97b136de923f156b9a60267724081cdfaee4ef935be248dd9ea5f6227L91-R113)
* Implemented the `prepare_command_mode_switch` method to handle switching between different control modes. [[1]](diffhunk://#diff-24099be97b136de923f156b9a60267724081cdfaee4ef935be248dd9ea5f6227R76-R80) [[2]](diffhunk://#diff-6273b1d2089bdf6913f5848f9a607c552501d1a65e573cc3adbf68bb5d3d7d9aR229-R327)

### Command and State Interface Handling:
* Updated the `export_state_interfaces` and `export_command_interfaces` methods to dynamically add state and command interfaces based on the joint configuration. [[1]](diffhunk://#diff-6273b1d2089bdf6913f5848f9a607c552501d1a65e573cc3adbf68bb5d3d7d9aR205-R219) [[2]](diffhunk://#diff-6273b1d2089bdf6913f5848f9a607c552501d1a65e573cc3adbf68bb5d3d7d9aR229-R327)
* Removed the `prev_command` member from the `Joint` struct and adjusted the `write` method to use the new control mode logic. [[1]](diffhunk://#diff-24099be97b136de923f156b9a60267724081cdfaee4ef935be248dd9ea5f6227L47-R58) [[2]](diffhunk://#diff-6273b1d2089bdf6913f5848f9a607c552501d1a65e573cc3adbf68bb5d3d7d9aL287-R467)

### Protocol-Specific Joint ID Management:
* Introduced separate vectors for TTL and RS protocol joint IDs and updated the `on_init` method to populate these vectors based on joint parameters. [[1]](diffhunk://#diff-24099be97b136de923f156b9a60267724081cdfaee4ef935be248dd9ea5f6227L91-R113) [[2]](diffhunk://#diff-6273b1d2089bdf6913f5848f9a607c552501d1a65e573cc3adbf68bb5d3d7d9aL70-R83)

### Additional Changes:
* Added support for reading and writing joint currents, including the necessary control items and sync read/write handlers. [[1]](diffhunk://#diff-6273b1d2089bdf6913f5848f9a607c552501d1a65e573cc3adbf68bb5d3d7d9aR32-R36) [[2]](diffhunk://#diff-6273b1d2089bdf6913f5848f9a607c552501d1a65e573cc3adbf68bb5d3d7d9aR129-R134)
* Updated the `read` and `write` methods to handle current-based control and the new `CurrentBasedPosition` control mode. [[1]](diffhunk://#diff-6273b1d2089bdf6913f5848f9a607c552501d1a65e573cc3adbf68bb5d3d7d9aR357-R403) [[2]](diffhunk://#diff-6273b1d2089bdf6913f5848f9a607c552501d1a65e573cc3adbf68bb5d3d7d9aL334-R485)